### PR TITLE
feat: add skills for volcano redis mcp server

### DIFF
--- a/skills/byted-redis-skills/LICENSE
+++ b/skills/byted-redis-skills/LICENSE
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 Beijing Volcano Engine Technology Co., Ltd. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/skills/byted-redis-skills/README.md
+++ b/skills/byted-redis-skills/README.md
@@ -1,0 +1,36 @@
+# Volcengine Redis MCP Skill
+
+This directory contains the Skill implementation for the Volcengine Redis MCP Server. It provides a standard interface for intelligent agents (such as Claude Code) to interact with Volcengine Redis via MCP.
+
+## Structure
+
+- **SKILL.md**: The manifest file for the skill. Agents parse this file to understand the skill capabilities and usage instructions.
+- **scripts/mcp_client.py**: A Python module acting as an MCP client for Volcengine Redis.
+- **scripts/call_redis_mcp_example.py**: A unified testing and example script. It lists tools and demonstrates how to invoke both parameterless tools (e.g., `describe_regions`) and parameterized tools (e.g., `describe_db_instances`).
+- **scripts/start_volcengine_redis_mcp.sh**: Starts the MCP server as a background process.
+- **scripts/stop_volcengine_redis_mcp.sh**: Stops the background MCP server.
+- **scripts/status_volcengine_redis_mcp.sh**: Checks the status of the background MCP server.
+
+## Installation & Setup
+
+1. Ensure `uv` is installed on your system.
+2. Obtain your Volcengine Access Key and Secret Key.
+3. Export them in your terminal:
+   ```bash
+   export VOLCENGINE_ACCESS_KEY="<your-ak>"
+   export VOLCENGINE_SECRET_KEY="<your-sk>"
+   export VOLCENGINE_REGION="cn-beijing"
+   ```
+
+## Client Support
+
+This skill is compatible with multiple agent clients:
+- **Claude Code**: It will read the `SKILL.md` file and directly execute the python scripts using `uv run`.
+- **Agentkit**: Can be loaded as a custom MCP skill via standard MCP SDKs.
+
+## Quick Test
+
+```bash
+cd skills
+uv run scripts/call_redis_mcp_example.py
+```

--- a/skills/byted-redis-skills/SKILL.md
+++ b/skills/byted-redis-skills/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: volcengine-redis-mcp
+description: A skill to launch and interact with the Volcengine Redis MCP Server. This skill enables agents to manage Redis instances, databases, accounts, backups, and configurations using the MCP protocol. It connects to Volcengine via the provided credentials.
+---
+
+# Volcengine Redis MCP Server Skill
+
+## 🔵 Overview
+This skill provides a complete set of tools to interact with Volcengine Redis using the Model Context Protocol (MCP). It allows users to query instances, manage parameters, and perform operational tasks on Volcengine Redis through natural language or programmatic invocation.
+
+---
+
+## Supported Tools
+
+The MCP Server exposes the following capabilities:
+1. `describe_regions` - Query available regional resources.
+2. `describe_zones` - Query available zone resources.
+3. `describe_vpcs` - Query VPCs.
+4. `describe_subnets` - Query subnets.
+5. `describe_db_instances` - List Redis instances.
+6. `describe_db_instance_detail` - View details for a specific instance.
+7. `describe_db_instance_specs` - List supported instance specs.
+8. `describe_slow_logs` - Query slow logs.
+9. `describe_hot_keys` - Query hot keys.
+10. `describe_big_keys` - Query big keys.
+11. `describe_backups` - Query backup list.
+12. `describe_db_instance_params` - List instance parameters.
+13. `describe_parameter_groups` - Query parameter templates.
+14. `describe_parameter_group_detail` - View parameter template details.
+15. `describe_allow_lists` - Query IP whitelists.
+16. `describe_allow_list_detail` - View whitelist details.
+17. `list_db_account` - Query database accounts.
+18. `create_db_instance` - Create a Redis instance.
+19. `modify_db_instance_params` - Modify parameter configurations.
+20. `create_db_account` - Create an account for a Redis instance.
+21. `create_allow_list` - Create a new IP whitelist.
+22. `associate_allow_list` - Bind a whitelist to an instance.
+23. `disassociate_allow_list` - Unbind a whitelist from an instance.
+24. `describe_db_instance_shards` - Query shard information.
+25. `describe_node_ids` - Query node IDs.
+26. `modify_db_instance_name` - Modify an instance's name.
+27. `describe_tags_by_resource` - Query tags.
+28. `describe_backup_plan` - Query backup plan.
+29. `describe_pitr_time_window` - Query PITR time window.
+30. `describe_backup_point_download_urls` - Get backup point download URLs.
+31. `describe_cross_region_backup_policy` - Query cross-region backup policy.
+32. `describe_cross_region_backups` - Query cross-region backups.
+33. `create_parameter_group` - Create a parameter group.
+34. `create_db_endpoint_public_address` - Create a public endpoint.
+35. `describe_db_instance_bandwidth_per_shard` - Query shard bandwidth.
+36. `describe_db_instance_acl_commands` - Query supported ACL commands.
+37. `describe_db_instance_acl_categories` - Query supported ACL categories.
+38. `describe_planned_events` - Query planned events.
+39. `describe_key_scan_jobs` - Query key scan jobs.
+40. `describe_eip_addresses` - Query EIP addresses.
+
+## 🔧 Prerequisites
+- Python 3.10+
+- `uv` package manager (installed)
+- Volcengine account with proper permissions for Redis and VPC services.
+
+## 🔐 Environment Variables
+Before running the skill, export the required credentials:
+```bash
+export VOLCENGINE_ACCESS_KEY="your-access-key"
+export VOLCENGINE_SECRET_KEY="your-secret-key"
+export VOLCENGINE_REGION="cn-beijing"  # Or your desired region
+```
+
+## 🚀 Usage
+
+### 1. Test & Client Example
+Use the provided script to verify the server and view usage examples:
+```bash
+uv run scripts/call_redis_mcp_example.py
+```
+
+### 2. Service Management (Optional)
+To run the server as a daemon:
+```bash
+./scripts/start_volcengine_redis_mcp.sh
+./scripts/status_volcengine_redis_mcp.sh
+./scripts/stop_volcengine_redis_mcp.sh
+```
+
+## 💻 Programmatic Usage via MCP Client
+
+You can use the provided Python scripts to programmatically call the MCP Server:
+
+```python
+import asyncio
+import sys
+# Ensure imports work from the scripts directory
+sys.path.append("scripts")
+from mcp_client import RedisMCPClient
+
+async def main():
+    async with RedisMCPClient() as client:
+        await client.connect()
+        
+        # List tools
+        tools = await client.list_tools()
+        print("Available tools:", [t['name'] for t in tools])
+        
+        # Call a tool
+        result = await client.call_tool("describe_db_instances", {})
+        print(result)
+
+asyncio.run(main())
+```

--- a/skills/byted-redis-skills/requirements.txt
+++ b/skills/byted-redis-skills/requirements.txt
@@ -1,0 +1,5 @@
+# Volcengine Redis MCP Skill Dependencies
+
+## Python Dependencies
+mcp>=1.1.0
+volcengine-python-sdk>=4.0.24

--- a/skills/byted-redis-skills/scripts/call_redis_mcp_example.py
+++ b/skills/byted-redis-skills/scripts/call_redis_mcp_example.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# /// script
+# dependencies = [
+#   "mcp>=1.0.0",
+# ]
+# ///
+
+import asyncio
+import sys
+from mcp_client import RedisMCPClient
+
+async def test_server():
+    print("Testing Volcengine Redis MCP Server...")
+    
+    try:
+        async with RedisMCPClient() as client:
+            print("\n1. Successfully connected to MCP server.")
+            
+            # --- 1. List available tools ---
+            tools = await client.list_tools()
+            print(f"\n2. Retrieved {len(tools)} tools:")
+            for i, tool in enumerate(tools[:5]):  # show first 5
+                print(f"  - {tool['name']}: {tool['description'][:60]}...")
+            if len(tools) > 5:
+                print(f"  ... and {len(tools) - 5} more tools.")
+                
+            # --- 2. Test a basic tool (no arguments required) ---
+            print("\n3. Testing tool invocation: describe_regions")
+            regions_result = await client.call_tool("describe_regions", {})
+            print("  Result:")
+            print(f"{regions_result}\n")
+            
+            # --- 3. Test an advanced tool with arguments ---
+            print("4. Testing tool invocation: describe_db_instances (with args)")
+            # Requesting only 1 instance to keep the output concise
+            instances_result = await client.call_tool("describe_db_instances", {
+                "region": "cn-beijing",
+                "pageSize": 1
+            })
+            print("  Result:")
+            try:
+                import json
+                data = json.loads(instances_result)
+                if "instances" in data and len(data["instances"]) > 0:
+                    data["instances"] = data["instances"][:1]
+                    data["_note"] = "Output truncated to 1 instance by test script for brevity"
+                print(f"{json.dumps(data, indent=2, ensure_ascii=False)}\n")
+            except Exception:
+                print(f"{instances_result}\n")
+            
+            print("\nAll tests passed successfully!")
+            
+    except Exception as e:
+        print(f"\nTest failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    asyncio.run(test_server())

--- a/skills/byted-redis-skills/scripts/mcp_client.py
+++ b/skills/byted-redis-skills/scripts/mcp_client.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# /// script
+# dependencies = [
+#   "mcp>=1.0.0",
+# ]
+# ///
+
+import asyncio
+import os
+import sys
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+class RedisMCPClient:
+    def __init__(self):
+        self.session = None
+        self._exit_stack = None
+
+    async def connect(self):
+        # Set up the server parameters
+        env = os.environ.copy()
+        
+        # Check required credentials
+        required_vars = ["VOLCENGINE_ACCESS_KEY", "VOLCENGINE_SECRET_KEY"]
+        missing_vars = [var for var in required_vars if var not in env]
+        if missing_vars:
+            print(f"Error: Missing required environment variables: {', '.join(missing_vars)}", file=sys.stderr)
+            print("Please set them using: export VOLCENGINE_ACCESS_KEY='...' export VOLCENGINE_SECRET_KEY='...'", file=sys.stderr)
+            sys.exit(1)
+
+        # To support standalone skill distribution without requiring local codebase,
+        # we default to using `uvx` to fetch and run the server from the remote repo.
+        server_params = StdioServerParameters(
+            command="uvx",
+            args=[
+                "--from",
+                "git+https://github.com/volcengine/mcp-server.git#subdirectory=server/mcp_server_redis",
+                "mcp-server-redis"
+            ],
+            env=env
+        )
+
+        from contextlib import AsyncExitStack
+        self._exit_stack = AsyncExitStack()
+        
+        # Start the client
+        try:
+            read, write = await self._exit_stack.enter_async_context(stdio_client(server_params))
+            self.session = await self._exit_stack.enter_async_context(ClientSession(read, write))
+            await self.session.initialize()
+        except Exception as e:
+            print(f"Failed to connect to MCP server: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    async def list_tools(self):
+        """List all available tools."""
+        if not self.session:
+            raise RuntimeError("Client not connected")
+        result = await self.session.list_tools()
+        tools = []
+        for t in result.tools:
+            tools.append({
+                "name": t.name,
+                "description": t.description
+            })
+        return tools
+
+    async def call_tool(self, name: str, arguments: dict = None):
+        """Call a specific tool."""
+        if not self.session:
+            raise RuntimeError("Client not connected")
+        arguments = arguments or {}
+        result = await self.session.call_tool(name, arguments)
+        
+        # Parse text content from response
+        output = ""
+        for content in result.content:
+            if content.type == 'text':
+                output += content.text + "\n"
+        return output
+
+    async def close(self):
+        if self._exit_stack:
+            await self._exit_stack.aclose()
+            self.session = None
+
+    async def __aenter__(self):
+        await self.connect()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.close()

--- a/skills/byted-redis-skills/scripts/mcp_client.py
+++ b/skills/byted-redis-skills/scripts/mcp_client.py
@@ -35,7 +35,9 @@ class RedisMCPClient:
             args=[
                 "--from",
                 "git+https://github.com/volcengine/mcp-server.git#subdirectory=server/mcp_server_redis",
-                "mcp-server-redis"
+                "mcp-server-redis",
+                "-t",
+                "stdio",
             ],
             env=env
         )

--- a/skills/byted-redis-skills/scripts/start_volcengine_redis_mcp.sh
+++ b/skills/byted-redis-skills/scripts/start_volcengine_redis_mcp.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Start Volcengine Redis MCP service as a background process
+
+LOG_DIR="logs"
+mkdir -p "$LOG_DIR"
+
+if [ -f "volcengine_redis_mcp.pid" ]; then
+    echo "Volcengine Redis MCP server is already running with PID $(cat volcengine_redis_mcp.pid)."
+    exit 1
+fi
+
+LOG_FILE="${LOG_DIR}/volcengine_redis_mcp_$(date +%Y%m%d_%H%M%S).log"
+
+# Use uvx to fetch and run the server from the remote Github repository
+# This makes the skill script completely standalone
+echo "Starting Volcengine Redis MCP Server..."
+nohup uvx --from git+https://github.com/volcengine/mcp-server.git#subdirectory=server/mcp_server_redis mcp-server-redis > "$LOG_FILE" 2>&1 &
+PID=$!
+
+echo $PID > volcengine_redis_mcp.pid
+echo "Volcengine Redis MCP Server started with PID $PID."
+echo "Logs are being written to $LOG_FILE"

--- a/skills/byted-redis-skills/scripts/start_volcengine_redis_mcp.sh
+++ b/skills/byted-redis-skills/scripts/start_volcengine_redis_mcp.sh
@@ -14,8 +14,7 @@ LOG_FILE="${LOG_DIR}/volcengine_redis_mcp_$(date +%Y%m%d_%H%M%S).log"
 # Use uvx to fetch and run the server from the remote Github repository
 # This makes the skill script completely standalone
 echo "Starting Volcengine Redis MCP Server..."
-nohup uvx --from git+https://github.com/volcengine/mcp-server.git#subdirectory=server/mcp_server_redis mcp-server-redis > "$LOG_FILE" 2>&1 &
-PID=$!
+nohup uvx --from git+https://github.com/volcengine/mcp-server.git#subdirectory=server/mcp_server_redis mcp-server-redis -t stdio > "$LOG_FILE" 2>&1 &PID=$!
 
 echo $PID > volcengine_redis_mcp.pid
 echo "Volcengine Redis MCP Server started with PID $PID."

--- a/skills/byted-redis-skills/scripts/status_volcengine_redis_mcp.sh
+++ b/skills/byted-redis-skills/scripts/status_volcengine_redis_mcp.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Check the status of the Volcengine Redis MCP service
+
+if [ ! -f "volcengine_redis_mcp.pid" ]; then
+    echo "Status: STOPPED (volcengine_redis_mcp.pid not found)"
+    exit 0
+fi
+
+PID=$(cat volcengine_redis_mcp.pid)
+if kill -0 $PID > /dev/null 2>&1; then
+    echo "Status: RUNNING (PID: $PID)"
+    echo "Recent logs:"
+    ls -t logs/volcengine_redis_mcp_*.log | head -1 | xargs tail -n 10
+else
+    echo "Status: STOPPED (PID file exists but process $PID is not running)"
+    rm volcengine_redis_mcp.pid
+fi

--- a/skills/byted-redis-skills/scripts/stop_volcengine_redis_mcp.sh
+++ b/skills/byted-redis-skills/scripts/stop_volcengine_redis_mcp.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Stop the background Volcengine Redis MCP service
+
+if [ ! -f "volcengine_redis_mcp.pid" ]; then
+    echo "No volcengine_redis_mcp.pid found. Server is likely not running."
+    exit 0
+fi
+
+PID=$(cat volcengine_redis_mcp.pid)
+if kill -0 $PID > /dev/null 2>&1; then
+    echo "Stopping Volcengine Redis MCP server with PID $PID..."
+    kill $PID
+    sleep 2
+    if kill -0 $PID > /dev/null 2>&1; then
+        echo "Force killing Volcengine Redis MCP server..."
+        kill -9 $PID
+    fi
+    echo "Volcengine Redis MCP server stopped."
+else
+    echo "Volcengine Redis MCP server process $PID not found. Cleaning up pid file."
+fi
+
+rm volcengine_redis_mcp.pid


### PR DESCRIPTION
## 背景

  • 为了让 Agent 能用 MCP 协议直接管理/查询火山引擎 Redis 资源，本 PR 引入 volcengine-redis-mcp skill，封装官方 volcengine/mcp-server 的
  mcp_server_redis（mcp-server-redis）。

 ## 改动内容

  • 新增技能目录 skills/byted-redis-skills/，包含 SKILL.md（能力与使用说明）、requirements.txt、以及基于 MCP stdio 的 Python
  client（scripts/mcp_client.py）和一键示例脚本（scripts/call_redis_mcp_example.py）。
  • 提供可选的常驻服务脚本：scripts/start_volcengine_redis_mcp.sh / status_volcengine_redis_mcp.sh / stop_volcengine_redis_mcp.sh，启动时显式指定 -t stdio。

 ## 如何验证

  • 设置环境变量：VOLCENGINE_ACCESS_KEY、VOLCENGINE_SECRET_KEY（可选 VOLCENGINE_REGION）。
  • 运行示例：uv run skills/byted-redis-skills/scripts/call_redis_mcp_example.py（会连接 MCP server、列出 tools，并调用示例 tool）。

 ## 影响范围

  • 纯新增能力，无破坏性变更；不影响现有 skills 行为。