### PR TITLE
fix(situla): support Windows config writes

### DIFF
--- a/python/01-tutorials/04-agentkit-tools/situla/src/config.ts
+++ b/python/01-tutorials/04-agentkit-tools/situla/src/config.ts
@@ -7,7 +7,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, isAbsolute, join } from "node:path";
+import { basename, dirname, isAbsolute, join } from "node:path";
 
 export const CONFIG_KEYS = [
   "VOLCENGINE_REGION",
@@ -135,7 +135,7 @@ function readSettingsFile<Key extends string>(
 function writeJsonAtomic(path: string, value: Record<string, string>): void {
   const temporaryPath = join(
     dirname(path),
-    `.${path.split("/").at(-1)}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`,
+    `.${basename(path)}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`,
   );
   writeFileSync(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
   renameSync(temporaryPath, path);

--- a/python/01-tutorials/04-agentkit-tools/situla/test/config.test.ts
+++ b/python/01-tutorials/04-agentkit-tools/situla/test/config.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { loadSitulaConfiguration, writeSitulaConfiguration } from "../src/config.ts";
@@ -31,13 +31,16 @@ test("configuration writer creates one private config file without credentials",
   const initial = loadSitulaConfiguration({ XDG_CONFIG_HOME: root });
   const values = { ...initial.values, VOLCENGINE_SERVICE: "agentkit_custom", VOLCENGINE_HOST: "agentkit-custom.example.com" };
   writeSitulaConfiguration(values, initial.paths);
-  assert.equal(statSync(initial.paths.directory).mode & 0o777, 0o700);
-  assert.equal(statSync(initial.paths.config).mode & 0o777, 0o600);
+  if (process.platform !== "win32") {
+    assert.equal(statSync(initial.paths.directory).mode & 0o777, 0o700);
+    assert.equal(statSync(initial.paths.config).mode & 0o777, 0o600);
+  }
   const config = JSON.parse(readFileSync(initial.paths.config, "utf8"));
   assert.equal(config.TOOL_TYPE, undefined);
   assert.equal(config.VOLCENGINE_SERVICE, "agentkit_custom");
   assert.equal(config.VOLCENGINE_ACCESS_KEY, undefined);
   assert.equal(config.VOLCENGINE_SESSION_TOKEN, undefined);
+  assert.deepEqual(readdirSync(initial.paths.directory), ["config.json"]);
 });
 
 test("legacy TOOL_TYPE is accepted while reading and removed on the next write", (context) => {


### PR DESCRIPTION
## Summary

- construct Situla's atomic configuration filename with the platform-aware path basename helper
- avoid asserting POSIX permission bits on Windows while retaining those checks on supported filesystems
- verify the atomic writer leaves only the final `config.json`

Fixes #253

## Tests

- `npm test` (81 passed)
- `npm run typecheck`
- `npm run build`
- `uvx pre-commit run --show-diff-on-failure --color=never --files python/01-tutorials/04-agentkit-tools/situla/src/config.ts python/01-tutorials/04-agentkit-tools/situla/test/config.test.ts`