### PR TITLE
fix(hybrid): close synchronous Runtime responses

### DIFF
--- a/python/02-use-cases/hybrid_cloud_customer_service/local_ui.py
+++ b/python/02-use-cases/hybrid_cloud_customer_service/local_ui.py
@@ -223,6 +223,7 @@ def chat(request: LocalChatRequest) -> dict[str, object]:
         )
     # The public Runtime gateway exposes /invoke, not the internal /apps routes.
     # AgentKit's compatibility endpoint creates the session on first request.
+    response = None
     try:
         response = requests.post(
             f"{endpoint}/invoke",
@@ -283,6 +284,9 @@ def chat(request: LocalChatRequest) -> dict[str, object]:
         raise HTTPException(502, detail=f"Runtime call failed: {exc}") from exc
     except (RuntimeError, ValueError) as exc:
         raise HTTPException(502, detail=f"Runtime stream failed: {exc}") from exc
+    finally:
+        if response is not None and hasattr(response, "close"):
+            response.close()
 
 
 @app.post("/ui/chat/stream")

--- a/python/02-use-cases/hybrid_cloud_customer_service/tests/test_local_ui.py
+++ b/python/02-use-cases/hybrid_cloud_customer_service/tests/test_local_ui.py
@@ -7,6 +7,7 @@ import subprocess
 from pathlib import Path
 
 import local_ui
+import pytest
 from fastapi.testclient import TestClient
 
 
@@ -44,6 +45,43 @@ class FakeJsonResponse:
             "citations": [{"title": "退款规则"}],
             "events": [{"name": "knowledge.search", "status": "succeeded"}],
         }
+
+
+class CloseTrackingResponse(FakeResponse):
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FailingCloseTrackingResponse(CloseTrackingResponse):
+    def raise_for_status(self) -> None:
+        raise local_ui.requests.ConnectionError("Runtime unavailable")
+
+
+def test_remote_ui_closes_response_after_success(monkeypatch) -> None:
+    monkeypatch.setenv("RUNTIME_ENDPOINT", "https://runtime.example/")
+    monkeypatch.setenv("RUNTIME_API_KEY", "test-key")
+    response = CloseTrackingResponse()
+    monkeypatch.setattr(local_ui.requests, "post", lambda *args, **kwargs: response)
+
+    local_ui.chat(local_ui.LocalChatRequest(message="测试"))
+
+    assert response.closed is True
+
+
+def test_remote_ui_closes_response_after_http_error(monkeypatch) -> None:
+    monkeypatch.setenv("RUNTIME_ENDPOINT", "https://runtime.example/")
+    monkeypatch.setenv("RUNTIME_API_KEY", "test-key")
+    response = FailingCloseTrackingResponse()
+    monkeypatch.setattr(local_ui.requests, "post", lambda *args, **kwargs: response)
+
+    with pytest.raises(local_ui.HTTPException) as exc_info:
+        local_ui.chat(local_ui.LocalChatRequest(message="测试"))
+
+    assert exc_info.value.status_code == 502
+    assert response.closed is True
 
 
 def test_remote_ui_omits_model_thought(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- close synchronous streamed Runtime responses in a `finally` block on every return and exception path
- add focused regression coverage for both a successful SSE response and an HTTP error
- mirror the lifecycle handling already used by the incremental streaming endpoint

Fixes #257

## Tests

- `$env:PYTHONUTF8='1'; uv run --frozen --extra dev pytest -q tests/test_local_ui.py -k remote_ui` (6 passed, 15 deselected)
- `$env:PYTHONUTF8='1'; uv run --frozen --extra dev pytest -q` (76 passed, 4 failed: the known evaluator regression addressed separately by #256, plus 3 Windows failures because this host has no usable Bash/WSL execution for shell-script tests)
- `uvx pre-commit run --show-diff-on-failure --color=never --files python/02-use-cases/hybrid_cloud_customer_service/local_ui.py python/02-use-cases/hybrid_cloud_customer_service/tests/test_local_ui.py`