### PR TITLE
docs: fix moved README links and paths

### DIFF
--- a/python/01-tutorials/01-agentkit-runtime/a2a_simple/README.md
+++ b/python/01-tutorials/01-agentkit-runtime/a2a_simple/README.md
@@ -401,7 +401,7 @@ a2a_app.run(agent_card=agent_card, host="0.0.0.0", port=8000)
 
 - [VeADK 官方文档](https://volcengine.github.io/veadk-python/)
 - [AgentKit 开发指南](https://volcengine.github.io/agentkit-sdk-python/)
-- [A2A 协议规范](https://github.com/google/adk)
+- [A2A 协议规范](https://github.com/google/adk-python)
 - [火山方舟模型服务](https://console.volcengine.com/ark/region:ark+cn-beijing/overview?briefPage=0&briefType=introduce&type=new&projectName=default)
 
 ## 代码许可

--- a/python/01-tutorials/01-agentkit-runtime/a2a_simple/README_en.md
+++ b/python/01-tutorials/01-agentkit-runtime/a2a_simple/README_en.md
@@ -403,7 +403,7 @@ None.
 
 - [VeADK Official Documentation](https://volcengine.github.io/veadk-python/)
 - [AgentKit Development Guide](https://volcengine.github.io/agentkit-sdk-python/)
-- [A2A Protocol Specification](https://github.com/google/adk)
+- [A2A Protocol Specification](https://github.com/google/adk-python)
 - [BytePlus ModelArk Service](https://console.byteplus.com/ark/region:ark+ap-southeast-1/overview)
 
 ## License

--- a/python/01-tutorials/01-agentkit-runtime/image_video_tools/README.md
+++ b/python/01-tutorials/01-agentkit-runtime/image_video_tools/README.md
@@ -351,7 +351,7 @@ from veadk.tools.builtin_tools.web_search import web_search
 - [VeADK 官方文档](https://volcengine.github.io/veadk-python/)
 - [AgentKit 开发指南](https://volcengine.github.io/agentkit-sdk-python/)
 - [火山方舟模型服务](https://console.volcengine.com/ark/region:ark+cn-beijing/overview?briefPage=0&briefType=introduce&type=new&projectName=default)
-- [视频生成工具文档](https://volcengine.github.io/veadk-python/tools/builtin/#video-generate)
+- [视频生成工具文档](https://volcengine.github.io/veadk-python/cn/docs/framework/tools/builtin/#视频生成video_generate)
 
 ## 代码许可
 

--- a/python/01-tutorials/01-agentkit-runtime/image_video_tools/README_en.md
+++ b/python/01-tutorials/01-agentkit-runtime/image_video_tools/README_en.md
@@ -353,7 +353,7 @@ None.
 - [VeADK Official Documentation](https://volcengine.github.io/veadk-python/)
 - [AgentKit Development Guide](https://volcengine.github.io/agentkit-sdk-python/)
 - [BytePlus ModelArk Service](https://console.byteplus.com/ark/region:ark+ap-southeast-1/overview)
-- [Video Generation Tool Documentation](https://volcengine.github.io/veadk-python/tools/builtin/#video-generate)
+- [Video Generation Tool Documentation](https://volcengine.github.io/veadk-python/cn/docs/framework/tools/builtin/#视频生成video_generate)
 
 ## Code License
 

--- a/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x/README.md
+++ b/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x/README.md
@@ -30,16 +30,16 @@ Skills Sandbox
 
 | 组件 | 描述 |
 | - | - |
-| **Agent 服务** | [agent.py](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-0.x.x/agent.py) - 主应用程序，定义 Agent 和记忆组件 |
-| **测试客户端** | [client.py](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-0.x.x/client.py) - SSE 流式调用客户端 |
-| **项目配置** | [pyproject.toml](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-0.x.x/pyproject.toml) - 依赖管理（uv 工具） |
+| **Agent 服务** | [agent.py](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x/agent.py) - 主应用程序，定义 Agent 和记忆组件 |
+| **测试客户端** | [client.py](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x/client.py) - SSE 流式调用客户端 |
+| **项目配置** | [pyproject.toml](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x/pyproject.toml) - 依赖管理（uv 工具） |
 | **AgentKit 配置** | agentkit.yaml - 云端部署配置文件 |
 | **短期记忆** | 使用本地后端存储会话上下文 |
 
 ## 目录结构说明
 
 ```bash
-skills_sandbox/veadk-0.x.x/
+skills_sandbox/veadk_0_x_x/
 ├── agent.py           # Agent 运行一个 skills 任务
 ├── client.py          # 测试客户端（SSE 流式调用）
 ├── requirements.txt   # Python 依赖列表 （agentkit部署时需要指定依赖文件)
@@ -78,7 +78,7 @@ brew install uv
 
 ```bash
 # 进入项目目录
-cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-0.x.x
+cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x
 ```
 
 您可以通过 `pip` 工具来安装本项目依赖：
@@ -120,7 +120,7 @@ export VOLCENGINE_SECRET_KEY=<Your Secret Key>
 
 ```bash
 # 进入项目目录
-cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-0.x.x
+cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x
 
 # 启动 VeADK Web 界面
 veadk web --port 8080
@@ -133,7 +133,7 @@ Web 界面提供图形化对话测试环境，支持实时查看消息流和调�
 此外，还可以使用命令行测试，调试 agent.py。
 
 ```bash
-cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-0.x.x
+cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x
 
 # 启动 Agent 服务
 uv run agent.py
@@ -176,7 +176,7 @@ export VOLCENGINE_SECRET_KEY=<Your Secret Key>
 ### AgentKit 云上部署
 
 ```bash
-cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-0.x.x
+cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x
 
 # 配置部署参数
 # optional：如果 agentkit config 中不添加 --runtime_envs AGENTKIT_TOOL_ID={{your_tool_id}}，可以在 AgentKit 控制台 智能体运行时 中，关键组件，选择 沙箱工具，并发布

--- a/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x/README_en.md
+++ b/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x/README_en.md
@@ -30,16 +30,16 @@ Skills Sandbox
 
 | Component | Description |
 | - | - |
-| **Agent Service** | [agent.py](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-0.x.x/agent.py) - Main application, defines the Agent and memory components |
-| **Test Client** | [client.py](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-0.x.x/client.py) - SSE streaming client |
-| **Project Configuration** | [pyproject.toml](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-0.x.x/pyproject.toml) - Dependency management (uv tool) |
+| **Agent Service** | [agent.py](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x/agent.py) - Main application, defines the Agent and memory components |
+| **Test Client** | [client.py](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x/client.py) - SSE streaming client |
+| **Project Configuration** | [pyproject.toml](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x/pyproject.toml) - Dependency management (uv tool) |
 | **AgentKit Configuration** | agentkit.yaml - Cloud deployment configuration file |
 | **Short-term Memory** | Uses a local backend to store session context |
 
 ## Directory Structure Explanation
 
 ```bash
-skills_sandbox/veadk-0.x.x/
+skills_sandbox/veadk_0_x_x/
 ├── agent.py           # Agent runs a skills task
 ├── client.py          # Test client (SSE streaming)
 ├── requirements.txt   # Python dependency list (required for agentkit deployment)
@@ -78,7 +78,7 @@ brew install uv
 
 ```bash
 # Enter the project directory
-cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-0.x.x
+cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x
 ```
 
 You can use the `pip` tool to install the project dependencies:
@@ -122,7 +122,7 @@ export BYTEPLUS_REGION=ap-southeast-1
 
 ```bash
 # Enter the project directory
-cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-0.x.x
+cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x
 
 # Start the VeADK Web UI
 veadk web --port 8080
@@ -135,7 +135,7 @@ The web interface provides a graphical dialogue testing environment, supporting 
 Alternatively, you can use the command line for testing and debugging agent.py.
 
 ```bash
-cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-0.x.x
+cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x
 
 # Start the Agent service
 uv run agent.py
@@ -180,7 +180,7 @@ export BYTEPLUS_REGION=ap-southeast-1
 ### AgentKit Cloud Deployment
 
 ```bash
-cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-0.x.x
+cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_0_x_x
 
 # Configure deployment parameters
 # optional: if you don't add --runtime_envs AGENTKIT_TOOL_ID={{your_tool_id}} in agentkit config, you can select the Sandbox tool in the AgentKit console's agent runtime and publish

--- a/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x/README.md
+++ b/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x/README.md
@@ -30,16 +30,16 @@ Skills Sandbox
 
 | 组件 | 描述 |
 | - | - |
-| **Agent 服务** | [agent.py](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-1.x.x/agent.py) - 主应用程序，定义 Agent 和记忆组件 |
-| **测试客户端** | [client.py](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-1.x.x/client.py) - SSE 流式调用客户端 |
-| **项目配置** | [pyproject.toml](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-1.x.x/pyproject.toml) - 依赖管理（uv 工具） |
+| **Agent 服务** | [agent.py](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x/agent.py) - 主应用程序，定义 Agent 和记忆组件 |
+| **测试客户端** | [client.py](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x/client.py) - SSE 流式调用客户端 |
+| **项目配置** | [pyproject.toml](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x/pyproject.toml) - 依赖管理（uv 工具） |
 | **AgentKit 配置** | agentkit.yaml - 云端部署配置文件 |
 | **短期记忆** | 使用本地后端存储会话上下文 |
 
 ## 目录结构说明
 
 ```bash
-skills_sandbox/veadk-1.x.x/
+skills_sandbox/veadk_1_x_x/
 ├── agent.py           # Agent 运行一个 skills 任务
 ├── client.py          # 测试客户端（SSE 流式调用）
 ├── requirements.txt   # Python 依赖列表 （agentkit部署时需要指定依赖文件)
@@ -78,7 +78,7 @@ brew install uv
 
 ```bash
 # 进入项目目录
-cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-1.x.x
+cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x
 ```
 
 您可以通过 `pip` 工具来安装本项目依赖：
@@ -123,7 +123,7 @@ export VOLCENGINE_SECRET_KEY=<Your Secret Key>
 
 ```bash
 # 进入项目目录
-cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-1.x.x
+cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x
 
 # 启动 VeADK Web 界面
 veadk web --port 8080
@@ -136,7 +136,7 @@ Web 界面提供图形化对话测试环境，支持实时查看消息流和调�
 此外，还可以使用命令行测试，调试 agent.py。
 
 ```bash
-cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-1.x.x
+cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x
 
 # 启动 Agent 服务
 uv run agent.py
@@ -182,7 +182,7 @@ export VOLCENGINE_SECRET_KEY=<Your Secret Key>
 ### AgentKit 云上部署
 
 ```bash
-cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-1.x.x
+cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x
 
 # 配置部署参数
 # optional：如果 agentkit config 中不添加 --runtime_envs AGENTKIT_TOOL_ID={{your_tool_id}}，可以在 AgentKit 控制台 智能体运行时 中，关键组件，选择 沙箱工具，并发布

--- a/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x/README_en.md
+++ b/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x/README_en.md
@@ -30,16 +30,16 @@ Skills Sandbox
 
 | Component | Description |
 | - | - |
-| **Agent Service** | [agent.py](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-1.x.x/agent.py) - Main application that defines the Agent and memory component |
-| **Test Client** | [client.py](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-1.x.x/client.py) - SSE streaming invocation client |
-| **Project Configuration** | [pyproject.toml](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-1.x.x/pyproject.toml) - Dependency management with uv |
+| **Agent Service** | [agent.py](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x/agent.py) - Main application that defines the Agent and memory component |
+| **Test Client** | [client.py](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x/client.py) - SSE streaming invocation client |
+| **Project Configuration** | [pyproject.toml](https://github.com/bytedance/agentkit-samples/blob/main/python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x/pyproject.toml) - Dependency management with uv |
 | **AgentKit Configuration** | agentkit.yaml - Cloud deployment configuration file |
 | **Short-Term Memory** | Stores session context using a local backend |
 
 ## Directory Structure
 
 ```bash
-skills_sandbox/veadk-1.x.x/
+skills_sandbox/veadk_1_x_x/
 ├── agent.py           # Agent runs a skills task
 ├── client.py          # Test client (SSE streaming invocation)
 ├── requirements.txt   # Python dependency list (must be specified during AgentKit deployment)
@@ -78,7 +78,7 @@ brew install uv
 
 ```bash
 # Enter the project directory
-cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-1.x.x
+cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x
 ```
 
 You can install this project's dependencies with `pip`:
@@ -125,7 +125,7 @@ export BYTEPLUS_REGION=ap-southeast-1
 
 ```bash
 # Enter the project directory
-cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-1.x.x
+cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x
 
 # Start the VeADK web UI
 veadk web --port 8080
@@ -138,7 +138,7 @@ The web UI provides a graphical conversation testing environment and supports re
 You can also use the command line to test and debug `agent.py`.
 
 ```bash
-cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-1.x.x
+cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x
 
 # Start the Agent service
 uv run agent.py
@@ -186,7 +186,7 @@ export BYTEPLUS_REGION=ap-southeast-1
 ### Deploy to AgentKit Cloud
 
 ```bash
-cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk-1.x.x
+cd python/01-tutorials/04-agentkit-tools/skills_sandbox/veadk_1_x_x
 
 # Configure deployment parameters
 # Optional: if you do not add --runtime_envs AGENTKIT_TOOL_ID={{your_tool_id}} in agentkit config,

--- a/python/02-use-cases/video_breakdown_agent/docs/README_CONFIG.md
+++ b/python/02-use-cases/video_breakdown_agent/docs/README_CONFIG.md
@@ -27,7 +27,7 @@ VeADK 按以下优先级（从高到低）读取配置：
 | 2 | `.env` 文件 | 项目根目录下，推荐用于本地开发 |
 | 3 | `config.yaml` | 项目根目录下，作为备选 |
 
-> 参考：[VeADK 配置项文档](https://volcengine.github.io/veadk-python/configuration/)
+> 参考：[VeADK 配置项文档](https://volcengine.github.io/veadk-python/cn/docs/references/configuration/)
 
 ## 工具返回数据优化策略
 
@@ -177,7 +177,7 @@ VEADK_TRACER_COZELOOP=true     # 启用 CozeLoop Exporter
 VEADK_TRACER_TLS=true          # 启用 TLS Exporter
 ```
 
-> 三种后端可任选其一或组合使用。详见 [VeADK 可观测文档](https://volcengine.github.io/veadk-python/observability/)。
+> 三种后端可任选其一或组合使用。详见 [VeADK 可观测文档](https://volcengine.github.io/veadk-python/cn/docs/framework/observability/)。
 
 ## config.yaml 与 .env 的对应关系
 


### PR DESCRIPTION
## Summary

- correct all hyphenated Skills Sandbox paths in the four `veadk_0_x_x` / `veadk_1_x_x` localized READMEs
- point the A2A READMEs to the current official `google/adk-python` repository
- update VeADK tool, configuration, and observability links to the current `/cn/docs/...` routes and actual video-generation anchor

Fixes #264

## Validation

- verified all six corrected GitHub source links return HTTP 200
- verified the Google ADK repository and three VeADK routes return HTTP 200
- verified the live builtin-tools page contains `id="视频生成video_generate"`
- verified no affected file retains the old hyphenated directories, `google/adk`, or removed VeADK routes
- `uvx pre-commit run --show-diff-on-failure --color=never --files <the nine changed README files>`
- `git diff --check`