### PR TITLE
fix(coffee_order, customer_support): fix incorrect knowledge initialization check logic

### DIFF
--- a/python/02-use-cases/coffee_order/agent.py
+++ b/python/02-use-cases/coffee_order/agent.py
@@ -43,16 +43,13 @@ if knowledge_collection_name != "":
 else:
     raise ValueError("DATABASE_VIKING_COLLECTION environment variable is not set")
 
-should_init_knowledge = False
+should_init_knowledge = True
 try:
     test_knowledge = knowledge.search("拿铁咖啡", top_k=1)
-    should_init_knowledge = not (
-        len(test_knowledge) >= 0
-        and test_knowledge[0].content != ""
-        and str(test_knowledge[0].content).__contains__("拿铁咖啡")
-    )
+    if test_knowledge and test_knowledge[0].content and "拿铁咖啡" in test_knowledge[0].content:
+        should_init_knowledge = False
 except Exception:
-    should_init_knowledge = True
+    pass
 
 if should_init_knowledge:
     # depend on tos bucket to upload knowledgebase content

--- a/python/02-use-cases/customer_support/assistant/agent.py
+++ b/python/02-use-cases/customer_support/assistant/agent.py
@@ -118,16 +118,13 @@ else:
     raise ValueError("DATABASE_VIKING_COLLECTION environment variable is not set")
 
 
-should_init_knowledge = False
+should_init_knowledge = True
 try:
     test_knowledge = knowledge.search(knowledge_probe, top_k=1)
-    should_init_knowledge = not (
-        len(test_knowledge) >= 0
-        and test_knowledge[0].content != ""
-        and str(test_knowledge[0].content).__contains__(knowledge_probe)
-    )
+    if test_knowledge and test_knowledge[0].content and knowledge_probe in test_knowledge[0].content:
+        should_init_knowledge = False
 except Exception:
-    should_init_knowledge = True
+    pass
 
 if should_init_knowledge:
     tos_bucket_name = os.getenv("DATABASE_TOS_BUCKET")


### PR DESCRIPTION
Summary
Fix the knowledge base initialization check logic used by both coffee_order and customer_support use-cases. The identical buggy snippet was originally introduced for customer_support and later copied to coffee_order. It contains a logic flaw that cannot reliably detect an empty knowledge base and may fall through to an IndexError disguised by the broad exception handler.

Bug Analysis
Both modified files share the same defects:

len(test_knowledge) >= 0 is always True for any list, so this check cannot detect an empty search result.
Because of (1), when the knowledge base is empty test_knowledge[0] is accessed directly on an empty list, which raises IndexError. The outer "except Exception" swallows it and happens to flip should_init_knowledge to True - the result is correct, but the decision is made through an unintended exception path instead of explicit logic.
str(x).contains(y) is an unpythonic way of writing "y in x".
The inverted structure "not (A and B and C)" reduces readability.
Affected lines:

python/02-use-cases/coffee_order/agent.py lines 46-55
python/02-use-cases/customer_support/assistant/agent.py lines 121-130
Changes
Before (old code):
```python
should_init_knowledge = False
try:
    test_knowledge = knowledge.search(probe, top_k=1)
    should_init_knowledge = not (
        len(test_knowledge) >= 0
        and test_knowledge[0].content != ""
        and str(test_knowledge[0].content).__contains__(probe)
    )
except Exception:
    should_init_knowledge = True
```
After (new code):
```python
should_init_knowledge = True
try:
    test_knowledge = knowledge.search(probe, top_k=1)
    if test_knowledge and test_knowledge[0].content and probe in test_knowledge[0].content:
        should_init_knowledge = False
except Exception:
    pass
```
Key points:

Default assumption = needs initialization (True), only flips to False when data is explicitly valid.
Leverages Python short-circuit evaluation: test_knowledge[0] is never evaluated when test_knowledge is empty, eliminating the IndexError at the source.
Replaces contains magic-method call with the idiomatic "in" operator.
Keeps the broad exception guard (any transient search failure still falls through to initialization), but uses "pass" instead of a redundant reassignment.
Files Changed
Modified 2 files, 8 insertions(+), 14 deletions(-):

python/02-use-cases/coffee_order/agent.py (-11 changed lines, new logic at lines 46-52)
python/02-use-cases/customer_support/assistant/agent.py (-11 changed lines, new logic at lines 121-127)
The two patches are symmetric; only the probe value differs (literal "拿铁咖啡" vs variable knowledge_probe).

Verification
Syntax check: python3 -m py_compile on both files -> OK
Static logic simulation, 8 scenarios ALL PASSED:
Empty list (uninitialized knowledge base) -> should_init = True, OK
List with empty-string content -> should_init = True, OK
List with non-matching content -> should_init = True, OK
List with exact matching content -> should_init = False, OK
Multi-item list, first item matches -> should_init = False, OK
Multi-item list, only second item matches -> should_init = True, OK (matches top_k=1 semantics)
None as input -> no exception leaked, OK
knowledge.search raises runtime error -> falls through to init, OK

